### PR TITLE
Adjusted SwaggerEndpoint creation so that the path starts from the base

### DIFF
--- a/src/SmartHotel.Services.Bookings/Startup.cs
+++ b/src/SmartHotel.Services.Bookings/Startup.cs
@@ -134,8 +134,7 @@ namespace SmartHotel.Services.Bookings
                 var b2cConfig = Configuration.GetSection("b2c");
                 var path = string.IsNullOrEmpty(pbase) || pbase == "/" ? "/" : $"{pbase}/";
                 c.InjectOnCompleteJavaScript($"{path}swagger-ui-b2c.js");
-                var prefix = string.IsNullOrEmpty(pbase) ? "" : $"{pbase}/";
-                c.SwaggerEndpoint($"{prefix}swagger/v1/swagger.json", "Bookings Api");
+                c.SwaggerEndpoint($"{path}swagger/v1/swagger.json", "Bookings Api");
                 c.ConfigureOAuth2(b2cConfig["ClientId"], "y", "z", "z", "",
                     new
                     {

--- a/src/SmartHotel.Services.Discount/Startup.cs
+++ b/src/SmartHotel.Services.Discount/Startup.cs
@@ -72,8 +72,8 @@ namespace SmartHotel.Services.Discount
             app.UseSwagger();
             app.UseSwaggerUI(c =>
             {
-                var prefix = string.IsNullOrEmpty(pbase) ? "" : $"{pbase}/";
-                c.SwaggerEndpoint($"{prefix}swagger/v1/swagger.json", "Discunts Api");
+                var path = string.IsNullOrEmpty(pbase) || pbase == "/" ? "/" : $"{pbase}/";
+                c.SwaggerEndpoint($"{path}swagger/v1/swagger.json", "Discounts Api");
             });
 
             app.UseMvc();

--- a/src/SmartHotel.Services.Hotels/Startup.cs
+++ b/src/SmartHotel.Services.Hotels/Startup.cs
@@ -141,8 +141,7 @@ namespace SmartHotel.Services.Hotels
                 var b2cConfig = Configuration.GetSection("b2c");
                 var path = string.IsNullOrEmpty(pbase) || pbase == "/" ? "/" : $"{pbase}/";
                 c.InjectOnCompleteJavaScript($"{path}swagger-ui-b2c.js");
-                var prefix = string.IsNullOrEmpty(pbase) ? "" : $"{pbase}/";
-                c.SwaggerEndpoint($"{prefix}swagger/v1/swagger.json", "Hotels Api");
+                c.SwaggerEndpoint($"{path}swagger/v1/swagger.json", "Hotels Api");
                 c.ConfigureOAuth2(b2cConfig["ClientId"], "y", "z", "z", "",
                     new
                     {

--- a/src/SmartHotel.Services.Notifications/Startup.cs
+++ b/src/SmartHotel.Services.Notifications/Startup.cs
@@ -106,8 +106,7 @@ namespace SmartHotels.Services.Notifications
                 var b2cConfig = Configuration.GetSection("b2c");
                 var path = string.IsNullOrEmpty(pbase) || pbase == "/" ? "/" : $"{pbase}/";
                 c.InjectOnCompleteJavaScript($"{path}swagger-ui-b2c.js");
-                var prefix = string.IsNullOrEmpty(pbase) ? "" : $"{pbase}/";
-                c.SwaggerEndpoint($"{prefix}swagger/v1/swagger.json", "Notifications Api");
+                c.SwaggerEndpoint($"{path}swagger/v1/swagger.json", "Notifications Api");
                 c.ConfigureOAuth2(b2cConfig["ClientId"], "y", "z", "z", "",
                     new
                     {

--- a/src/SmartHotel.Services.Profiles/Startup.cs
+++ b/src/SmartHotel.Services.Profiles/Startup.cs
@@ -72,8 +72,8 @@ namespace SmartHotel.Services.Profiles
             app.UseSwagger();
             app.UseSwaggerUI(c =>
             {
-                var prefix = string.IsNullOrEmpty(pbase) ? "" : $"{pbase}/";
-                c.SwaggerEndpoint($"{prefix}swagger/v1/swagger.json", "Profiles Api");
+                var path = string.IsNullOrEmpty(pbase) || pbase == "/" ? "/" : $"{pbase}/";
+                c.SwaggerEndpoint($"{path}swagger/v1/swagger.json", "Profiles Api");
 
             });
 

--- a/src/SmartHotel.Services.ReviewsNet/Startup.cs
+++ b/src/SmartHotel.Services.ReviewsNet/Startup.cs
@@ -83,8 +83,8 @@ namespace SmartHotel.Services.ReviewsNet
             app.UseSwagger();
             app.UseSwaggerUI(c =>
             {
-                var prefix = string.IsNullOrEmpty(pbase) ? "" : $"{pbase}/";
-                c.SwaggerEndpoint($"{prefix}swagger/v1/swagger.json", "Reviews Api");
+                var path = string.IsNullOrEmpty(pbase) || pbase == "/" ? "/" : $"{pbase}/";
+                c.SwaggerEndpoint($"{path}swagger/v1/swagger.json", "Reviews Api");
 
             });
 


### PR DESCRIPTION
#14 The swagger links default to http://address:port/swagger/swagger/v1/swagger.json but should just be http://address:port/swagger/v1/swagger.json.

I've adjusted the SwaggerEndpoint creation to use the path variable, which is based on the root.